### PR TITLE
Import Identity Reaper

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: v0.1.3
-appVersion: v0.1.3
+version: v0.1.4
+appVersion: v0.1.4
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/unikorn/main/icons/default.png

--- a/charts/region/templates/region-controller/clusterrole.yaml
+++ b/charts/region/templates/region-controller/clusterrole.yaml
@@ -29,3 +29,10 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch

--- a/charts/region/templates/region-controller/ingress.yaml
+++ b/charts/region/templates/region-controller/ingress.yaml
@@ -16,7 +16,9 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.region.ingress.host }}
   {{- end }}
 spec:
+  {{- if .Values.region.ingress.class }}
   ingressClassName: {{ .Values.region.ingress.class }}
+  {{- end }}
   # For development you will want to add these names to /etc/hosts for the ingress
   # endpoint address.
   tls:

--- a/charts/region/values.yaml
+++ b/charts/region/values.yaml
@@ -71,7 +71,7 @@ region:
 
   ingress:
     # Sets the ingress class to use.
-    class: nginx
+    # class: nginx
 
     # Sets the DNS hosts/X.509 Certs.
     host: region.unikorn-cloud.org

--- a/cmd/unikorn-region-controller/main.go
+++ b/cmd/unikorn-region-controller/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/client"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/reaper"
 	"github.com/unikorn-cloud/region/pkg/server"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -73,6 +74,12 @@ func start() {
 	server, err := s.GetServer(client)
 	if err != nil {
 		logger.Error(err, "failed to setup Handler")
+
+		return
+	}
+
+	if err := reaper.New(client, s.Options.Namespace).Run(ctx); err != nil {
+		logger.Error(err, "failed to setup 'The Reaper'")
 
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,11 @@ go 1.22.1
 require (
 	github.com/getkin/kin-openapi v0.123.0
 	github.com/go-chi/chi/v5 v5.0.12
-	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud/v2 v2.0.0-rc.3
 	github.com/gophercloud/utils v0.0.0-20231010081019-80377eca5d56
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.5
-	github.com/unikorn-cloud/core v0.1.45
+	github.com/unikorn-cloud/core v0.1.46
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
@@ -41,6 +40,7 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gophercloud/gophercloud v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.45 h1:EmnY4p3LWrCSPQVc/jgPN/i3Oau7TFS1PQyMPKwwXSM=
-github.com/unikorn-cloud/core v0.1.45/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
+github.com/unikorn-cloud/core v0.1.46 h1:bkRIMQt8zdAoPtXut5nngzqIweU9QpVyYm447KjE9ic=
+github.com/unikorn-cloud/core v0.1.46/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -133,13 +133,17 @@ func (h *Handler) GetApiV1RegionsRegionIDFlavors(w http.ResponseWriter, r *http.
 	}
 
 	// Apply ordering guarantees, ascending order with GPUs taking precedence over
-	// CPUs.
+	// CPUs and memory.
 	slices.SortFunc(result, func(a, b providers.Flavor) int {
 		if v := cmp.Compare(a.GPUs, b.GPUs); v != 0 {
 			return v
 		}
 
-		return cmp.Compare(a.CPUs, b.CPUs)
+		if v := cmp.Compare(a.CPUs, b.CPUs); v != 0 {
+			return v
+		}
+
+		return cmp.Compare(a.Memory.Value(), b.Memory.Value())
 	})
 
 	out := make(openapi.Flavors, len(result))

--- a/pkg/providers/interfaces.go
+++ b/pkg/providers/interfaces.go
@@ -32,6 +32,8 @@ type Provider interface {
 	Images(ctx context.Context) (ImageList, error)
 	// CreateIdentity creates a new identity for cloud infrastructure.
 	CreateIdentity(ctx context.Context, info *ClusterInfo) (*unikornv1.Identity, *CloudConfig, error)
+	// DeleteIdentity cleans up an identity for cloud infrastructure.
+	DeleteIdentity(ctx context.Context, identityID string) error
 	// ListExternalNetworks returns a list of external networks if the platform
 	// supports such a concept.
 	ListExternalNetworks(ctx context.Context) (ExternalNetworks, error)

--- a/pkg/reaper/reaper.go
+++ b/pkg/reaper/reaper.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/handler/region"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	ErrInvalidClient = errors.New("client invalid")
+
+	ErrDataMissing = errors.New("data missing")
+
+	ErrUnexpectedType = errors.New("unexpected type")
+
+	ErrCleanup = errors.New("cleanup failed")
+)
+
+// Seasons don't fear the reaper, nor do wind or the sun or the rain.
+// Peforms asynchronous cleanup tasks.
+type Reaper struct {
+	client    client.Client
+	namespace string
+}
+
+func New(client client.Client, namespace string) *Reaper {
+	return &Reaper{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+func (r *Reaper) Run(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	watchingClient, ok := r.client.(client.WithWatch)
+	if !ok {
+		return fmt.Errorf("%w: client does not implement watches", ErrInvalidClient)
+	}
+
+	// TODO: This is insecure, enything can raise an event and have identities deleted.
+	// We should syncronously trigger the cleanup from various component deprovisioners
+	// but then you are faced with the problem that there is no access token to allow
+	// API access.
+	options := &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{
+			"reason": constants.IdentityCleanupReadyEventReason,
+		}),
+	}
+
+	// Please note when using Kubernetes watches of events that you may see
+	// some historical events for things in the last hour.
+	go func() {
+		var zeroEvent watch.Event
+
+		for {
+			var events corev1.EventList
+
+			watcher, err := watchingClient.Watch(ctx, &events, options)
+			if err != nil {
+				log.Error(err, "failed to setup watch")
+				continue
+			}
+
+			eventStream := watcher.ResultChan()
+
+			for {
+				event := <-eventStream
+
+				// Zero value returned, closed channel, this happens, start it back
+				// up again...
+				if event == zeroEvent {
+					break
+				}
+
+				log.V(1).Info("witnessed an event", "event", event)
+
+				if event.Type != watch.Added {
+					continue
+				}
+
+				realEvent, ok := event.Object.(*corev1.Event)
+				if !ok {
+					log.Error(ErrUnexpectedType, "unable to decode event")
+				}
+
+				if err := r.handleEvent(ctx, realEvent); err != nil {
+					log.Error(err, "event handling failed")
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (r *Reaper) handleEvent(ctx context.Context, event *corev1.Event) error {
+	log := log.FromContext(ctx)
+
+	log.Info("processing cluster deletion event", "event", event)
+
+	regionID, ok := event.Annotations[constants.RegionAnnotation]
+	if !ok {
+		return fmt.Errorf("%w: region annotation not present", ErrDataMissing)
+	}
+
+	identityID, ok := event.Annotations[constants.CloudIdentityAnnotation]
+	if !ok {
+		return fmt.Errorf("%w: identity annotation not present", ErrDataMissing)
+	}
+
+	provider, err := region.NewClient(r.client, r.namespace).Provider(ctx, regionID)
+	if err != nil {
+		return fmt.Errorf("%w: failed to create provider client", err)
+	}
+
+	if err := provider.DeleteIdentity(ctx, identityID); err != nil {
+		return fmt.Errorf("%w: failed to delete identity", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
In lieu of a proper solution that involves APIs and access tokens import the reaper, let it listen to all events in the system, filtered by the specific reason that a cluster would raise when deprovioning is done asynchronously and then delete that identity.