### PR TITLE
Fix Image Listing

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: v0.1.14
-appVersion: v0.1.14
+version: v0.1.15
+appVersion: v0.1.15
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/providers/openstack/image.go
+++ b/pkg/providers/openstack/image.go
@@ -181,7 +181,11 @@ func (c *ImageClient) Images(ctx context.Context) ([]images.Image, error) {
 	_, span := tracer.Start(ctx, "/imageservice/v2/images", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
-	page, err := images.List(c.client, &images.ListOpts{}).AllPages(ctx)
+	opts := &images.ListOpts{
+		Visibility: images.ImageVisibilityPublic,
+	}
+
+	page, err := images.List(c.client, opts).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When listing images, unscoped, OpenStack will error if someone has a shared image, rather than filtering it out, sigh.  Manually filter on public images.