### PR TITLE
Make Regions Organization Scoped

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: v0.1.20
-appVersion: v0.1.20
+version: v0.1.21
+appVersion: v0.1.21
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	github.com/unikorn-cloud/core v0.1.60
-	github.com/unikorn-cloud/identity v0.2.25
+	github.com/unikorn-cloud/identity v0.2.26
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v0.1.60 h1:N/4xkv3dNv8/ZM3VqyxsECm2Ji/gE3QBoLjGsEUQTg4=
 github.com/unikorn-cloud/core v0.1.60/go.mod h1:Cd0zU1LrKo+OwnnCwuTQ+QL3yibnkjDHtkujfDM4AdE=
-github.com/unikorn-cloud/identity v0.2.25 h1:nb45gnI8o/12idVodWtAVO5WRFW8cTg6PFQHYjLd3DM=
-github.com/unikorn-cloud/identity v0.2.25/go.mod h1:8WxgWetyrCvLjRGAeEWy5hWXDJ8prVz+FNt9sG17lV8=
+github.com/unikorn-cloud/identity v0.2.26 h1:wvyWSe188RwgKjfvCfHlTvOjpbGdQtXwohFV77WTnDg=
+github.com/unikorn-cloud/identity v0.2.26/go.mod h1:8WxgWetyrCvLjRGAeEWy5hWXDJ8prVz+FNt9sG17lV8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
After playing with the UI, it semms quite apparent that mapping a region ID to a name, when the region is itself project scoped is quite heavy weight and unwieldy.  To remedy this we move regions back to the organization scope so we need only a single lookup, relying on RBAC information to do any filtering.  This also splits up regions and instrastructure so readers can map to regions, but not create identities etc.