### PR TITLE
Update Creation Auditing

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: v0.1.21
-appVersion: v0.1.21
+version: v0.1.22
+appVersion: v0.1.22
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	github.com/unikorn-cloud/core v0.1.60
-	github.com/unikorn-cloud/identity v0.2.26
+	github.com/unikorn-cloud/core v0.1.62
+	github.com/unikorn-cloud/identity v0.2.28
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -138,10 +138,10 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.60 h1:N/4xkv3dNv8/ZM3VqyxsECm2Ji/gE3QBoLjGsEUQTg4=
-github.com/unikorn-cloud/core v0.1.60/go.mod h1:Cd0zU1LrKo+OwnnCwuTQ+QL3yibnkjDHtkujfDM4AdE=
-github.com/unikorn-cloud/identity v0.2.26 h1:wvyWSe188RwgKjfvCfHlTvOjpbGdQtXwohFV77WTnDg=
-github.com/unikorn-cloud/identity v0.2.26/go.mod h1:8WxgWetyrCvLjRGAeEWy5hWXDJ8prVz+FNt9sG17lV8=
+github.com/unikorn-cloud/core v0.1.62 h1:EbXZxQxBIYjWC/LVLw8xAd46609u5GLc2DxnrZnLYxE=
+github.com/unikorn-cloud/core v0.1.62/go.mod h1:Cd0zU1LrKo+OwnnCwuTQ+QL3yibnkjDHtkujfDM4AdE=
+github.com/unikorn-cloud/identity v0.2.28 h1:tJqkcTurte0oEHUW6EUjcZ69x2z0KI8puHSBKHF6ECE=
+github.com/unikorn-cloud/identity v0.2.28/go.mod h1:k3Dfr604vlP5ryJJsFc412vgaIuztCzxsuiQwa3ws1Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
To actually audit resource creation meaningfully, we need to get the resource ID, and the only way to do that in a generic way is to return the generated resource in all POST APIs.