### PR TITLE
Add Server Group Cleanup

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: v0.1.29
-appVersion: v0.1.29
+version: v0.1.30
+appVersion: v0.1.30
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/region/crds/region.unikorn-cloud.org_identities.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_identities.yaml
@@ -68,6 +68,9 @@ spec:
                     description: CloudConfig is a client compatible cloud configuration.
                     format: byte
                     type: string
+                  password:
+                    description: Password is the login for the user.
+                    type: string
                   projectID:
                     description: ProjectID is the ID of the project created for the
                       identity.
@@ -82,6 +85,7 @@ spec:
                 required:
                 - cloud
                 - cloudConfig
+                - password
                 - projectID
                 - userID
                 type: object

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -307,6 +307,8 @@ type IdentitySpecOpenStack struct {
 	Cloud string `json:"cloud"`
 	// UserID is the ID of the user created for the identity.
 	UserID string `json:"userID"`
+	// Password is the login for the user.
+	Password string `json:"password"`
 	// ProjectID is the ID of the project created for the identity.
 	ProjectID string `json:"projectID"`
 	// ServerGroupID is the ID of the server group created for the identity.

--- a/pkg/providers/openstack/blockstorage.go
+++ b/pkg/providers/openstack/blockstorage.go
@@ -55,7 +55,7 @@ func NewBlockStorageClient(ctx context.Context, provider CredentialProvider) (*B
 
 // AvailabilityZones retrieves block storage availability zones.
 func (c *BlockStorageClient) AvailabilityZones(ctx context.Context) ([]availabilityzones.AvailabilityZone, error) {
-	url := c.client.ServiceURL("os-availability-zone")
+	url := c.client.ServiceURL("GET /block-storage/v3/os-availability-zone")
 
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 

--- a/pkg/providers/openstack/identity.go
+++ b/pkg/providers/openstack/identity.go
@@ -143,7 +143,7 @@ func (o *CreateTokenOptionsScopedToken) Options() *tokens.AuthOptions {
 func (c *IdentityClient) CreateToken(ctx context.Context, options CreateTokenOptions) (*tokens.Token, *tokens.User, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/auth/tokens", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "POST /identity/v3/auth/tokens", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	result := tokens.Create(ctx, c.client, options.Options())
@@ -165,7 +165,7 @@ func (c *IdentityClient) CreateToken(ctx context.Context, options CreateTokenOpt
 func (c *IdentityClient) CreateProject(ctx context.Context, domainID, name string, tags []string) (*projects.Project, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/auth/projects", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "POST /identity/v3/auth/projects", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	// TODO: pass ID in from configuration.
@@ -181,7 +181,7 @@ func (c *IdentityClient) CreateProject(ctx context.Context, domainID, name strin
 func (c *IdentityClient) DeleteProject(ctx context.Context, projectID string) error {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/auth/projects/"+projectID, trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "DELETE /identity/v3/auth/projects/"+projectID, trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	return projects.Delete(ctx, c.client, projectID).Err
@@ -192,7 +192,7 @@ func (c *IdentityClient) DeleteProject(ctx context.Context, projectID string) er
 func (c *IdentityClient) ListAvailableProjects(ctx context.Context) ([]projects.Project, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/auth/projects", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "GET /identity/v3/auth/projects", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	page, err := projects.ListAvailable(c.client).AllPages(ctx)
@@ -216,7 +216,7 @@ func (c *IdentityClient) ListRoles(ctx context.Context) ([]roles.Role, error) {
 
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/auth/roles", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "GIT /identity/v3/auth/roles", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	page, err := roles.List(c.client, &roles.ListOpts{}).AllPages(ctx)
@@ -238,7 +238,7 @@ func (c *IdentityClient) ListRoles(ctx context.Context) ([]roles.Role, error) {
 func (c *IdentityClient) CreateRoleAssignment(ctx context.Context, userID, projectID, roleID string) error {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/auth/role_assignments", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "POST /identity/v3/auth/role_assignments", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	opts := roles.AssignOpts{
@@ -258,7 +258,7 @@ func (c *IdentityClient) CreateRoleAssignment(ctx context.Context, userID, proje
 func (c *IdentityClient) ListApplicationCredentials(ctx context.Context, userID string) ([]applicationcredentials.ApplicationCredential, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/users/"+userID+"/application_credentials", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "GET /identity/v3/users/"+userID+"/application_credentials", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	page, err := applicationcredentials.List(c.client, userID, nil).AllPages(ctx)
@@ -278,7 +278,7 @@ func (c *IdentityClient) ListApplicationCredentials(ctx context.Context, userID 
 func (c *IdentityClient) CreateApplicationCredential(ctx context.Context, userID, name, description string, roles []string) (*applicationcredentials.ApplicationCredential, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/users/"+userID+"/application_credentials", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "POST /identity/v3/users/"+userID+"/application_credentials", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	applicationRoles := make([]applicationcredentials.Role, len(roles))
@@ -305,7 +305,7 @@ func (c *IdentityClient) CreateApplicationCredential(ctx context.Context, userID
 func (c *IdentityClient) DeleteApplicationCredential(ctx context.Context, userID, id string) error {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/users/"+userID+"/application_credentials/"+id, trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "DELETE /identity/v3/users/"+userID+"/application_credentials/"+id, trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	return applicationcredentials.Delete(ctx, c.client, userID, id).ExtractErr()
@@ -315,7 +315,7 @@ func (c *IdentityClient) DeleteApplicationCredential(ctx context.Context, userID
 func (c *IdentityClient) CreateUser(ctx context.Context, domainID, name, password string) (*users.User, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/users", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "POST /identity/v3/users", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	opts := &users.CreateOpts{
@@ -331,7 +331,7 @@ func (c *IdentityClient) CreateUser(ctx context.Context, domainID, name, passwor
 func (c *IdentityClient) GetUser(ctx context.Context, userID string) (*users.User, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/users/"+userID, trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "GET /identity/v3/users/"+userID, trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	return users.Get(ctx, c.client, userID).Extract()
@@ -341,7 +341,7 @@ func (c *IdentityClient) GetUser(ctx context.Context, userID string) (*users.Use
 func (c *IdentityClient) DeleteUser(ctx context.Context, userID string) error {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/identity/v3/users/"+userID, trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "DELETE /identity/v3/users/"+userID, trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	return users.Delete(ctx, c.client, userID).Err

--- a/pkg/providers/openstack/image.go
+++ b/pkg/providers/openstack/image.go
@@ -178,7 +178,7 @@ func (c *ImageClient) images(ctx context.Context) ([]images.Image, error) {
 
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/imageservice/v2/images", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "GET /image/v2/images", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	opts := &images.ListOpts{

--- a/pkg/providers/openstack/network.go
+++ b/pkg/providers/openstack/network.go
@@ -89,7 +89,7 @@ func (c *NetworkClient) externalNetworks(ctx context.Context) ([]networks.Networ
 
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/networking/v2.0/networks", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "GET /network/v2.0/networks", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	affirmative := true
@@ -188,7 +188,7 @@ func (c *NetworkClient) CreateVLANProviderNetwork(ctx context.Context, name stri
 
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
-	_, span := tracer.Start(ctx, "/networking/v2.0/networks", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := tracer.Start(ctx, "POST /network/v2.0/networks", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	opts := &provider.CreateOptsExt{


### PR DESCRIPTION
Nova just orphans things on project deletion, which leaves a bunch of server groups hanging around in the aether, so we should play nice and clean these up for it, and make life easier on our platform teams.