### PR TITLE
Fix Router Provision Bug

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: v0.1.40
-appVersion: v0.1.40
+version: v0.1.41
+appVersion: v0.1.41
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/providers/openstack/provider.go
+++ b/pkg/providers/openstack/provider.go
@@ -936,7 +936,7 @@ func (p *Provider) createRouter(ctx context.Context, networkService *NetworkClie
 
 	router, err := networkService.CreateRouter(ctx, "unikorn-openstack-region-provider-router")
 	if err != nil {
-		return nil
+		return err
 	}
 
 	openstackPhysicalNetwork.Spec.RouterID = &router.ID


### PR DESCRIPTION
Error is not getting propagated, and annoyingly the linter didn't pick this up, meaning we say it's okay when a router fails to provision e.g. no more IP addresses, and we get a SIGSEGV.