### PR TITLE
Return server status

### DIFF
--- a/pkg/handler/server/conversion.go
+++ b/pkg/handler/server/conversion.go
@@ -60,6 +60,10 @@ func convert(in *unikornv1.Server) *openapi.ServerRead {
 			PublicIPAllocation: convertServerPublicIPAllocation(in.Spec.PublicIPAllocation),
 			SecurityGroups:     convertServerSecurityGroups(in.Spec.SecurityGroups),
 		},
+		Status: openapi.ServerReadStatus{
+			PrivateIP: in.Status.PrivateIP,
+			PublicIP:  in.Status.PublicIP,
+		},
 	}
 
 	if tags := convertTags(in.Spec.Tags); tags != nil {


### PR DESCRIPTION
This PR addresses a small fix to the server API endpoints by populating and returning the `status` field in the server response. Specifically, it ensures that the status field includes both the `public and private IP` addresses of the provisioned server.

The status field, which is already specified in the `server.spec.yaml` file, will now contain these IPs, allowing client services like Compute and Slonk to be aware of the server's provisioned network interfaces.