### PR TITLE
Add description to openstack floating ip

### DIFF
--- a/pkg/providers/openstack/network.go
+++ b/pkg/providers/openstack/network.go
@@ -372,6 +372,7 @@ func (c *NetworkClient) CreateFloatingIP(ctx context.Context, portID string) (*f
 	opts := &floatingips.CreateOpts{
 		FloatingNetworkID: externalNetworks[0].ID,
 		PortID:            portID,
+		Description:       "unikorn managed floating IP",
 	}
 
 	floatingIP, err := floatingips.Create(ctx, c.client, opts).Extract()


### PR DESCRIPTION

This PR adds a description to OpenStack floating IPs to indicate that the resource is managed by Unikorn. This enables OpenStack administrators to easily distinguish resources provisioned by Unikorn from others and trace the source of the resource. Other resources provisioned by the Unikorn OpenStack provider already include this distinction.